### PR TITLE
fix(interact): add withdrawal support for 1.x api of IDisputeResolver

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -286,20 +286,36 @@ class App extends React.Component {
 
   getTotalWithdrawableAmount = async (arbitrableDisputeID, contributedTo, arbitrated) => {
     let amount = 0;
-    let counter = 0;
-    while (counter < contributedTo.length) {
-      amount = await EthereumInterface.call(
+
+    try {
+      // function signature withdrawFeesAndRewardsForAllRounds(uint256 _localDisputeID, address payable _contributor, uint256 _ruling);
+      let counter = 0;
+      while (counter < contributedTo.length) {
+        amount = await EthereumInterface.call(
+          "IDisputeResolver",
+          arbitrated,
+          "getTotalWithdrawableAmount",
+          arbitrableDisputeID,
+          this.state.activeAddress ? this.state.activeAddress : ADDRESS_ZERO,
+          contributedTo[counter]
+        );
+        if (amount != 0) break;
+        counter++;
+      }
+      return { amount: amount, ruling: contributedTo[counter] };
+    } catch {
+      // function signature withdrawFeesAndRewardsForAllRounds(uint256 _localDisputeID, address payable _contributor, uint256[] memory _contributedTo);
+      amount = amount = await EthereumInterface.call(
         "IDisputeResolver",
         arbitrated,
         "getTotalWithdrawableAmount",
         arbitrableDisputeID,
         this.state.activeAddress ? this.state.activeAddress : ADDRESS_ZERO,
-        contributedTo[counter]
+        contributedTo
       );
-      if (amount != 0) break;
-      counter++;
+
+      return { amount: amount, ruling: 0 };
     }
-    return { amount: amount, ruling: contributedTo[counter] };
   };
 
   getDispute = async (arbitratorDisputeID) => EthereumInterface.call("KlerosLiquid", networkMap[this.state.network].KLEROS_LIQUID, "getDispute", arbitratorDisputeID);

--- a/src/containers/interact.js
+++ b/src/containers/interact.js
@@ -97,7 +97,13 @@ class Interact extends React.Component {
 
   withdraw = async () => {
     console.debug([Object.keys(this.state.contributions).map((key) => parseInt(key))]);
-    this.props.withdrawCallback(this.state.arbitrated, this.state.arbitrableDisputeID, this.state.selectedContribution);
+    try {
+      // function signature withdrawFeesAndRewardsForAllRounds(uint256 _localDisputeID, address payable _contributor, uint256 _ruling);
+      this.props.withdrawCallback(this.state.arbitrated, this.state.arbitrableDisputeID, this.state.selectedContribution);
+    } catch {
+      // function signature withdrawFeesAndRewardsForAllRounds(uint256 _localDisputeID, address payable _contributor, uint256[] memory _contributedTo);
+      this.props.withdrawCallback(this.state.arbitrated, this.state.arbitrableDisputeID, [this.state.selectedContribution]);
+    }
   };
 
   getWithdrawAmount = async () =>


### PR DESCRIPTION
`getTotalWithdrawableAmount` and `withdrawFeesAndRewardsForAllRounds` function signatures have minor changes between 1.x and 2.x `IDisputeResolver`. This pull implements support to 1.x functionality. (Unslashed was deployed with 1.x, and that's the only contract deployed with this version, that's why this patch is an exception for Unslashed).