### PR TITLE
fix: use cdn.kleros.link in evidence

### DIFF
--- a/src/components/evidenceTimeline.js
+++ b/src/components/evidenceTimeline.js
@@ -280,7 +280,7 @@ EvidenceTimeline.propTypes = {
 };
 
 EvidenceTimeline.defaultProps = {
-  ipfsGateway: "https://ipfs.kleros.io",
+  ipfsGateway: "https://cdn.kleros.link",
   publishCallback: async (e) => {
     console.error(e);
     await new Promise((r) => setTimeout(r, 4000));


### PR DESCRIPTION
using `src/urlNormalizer.js` for everything is probably superior, just wanted a quick patch

many things in the codebase are not using this function