### PR TITLE
fix:  return absolute http(s) URLs unchanged

### DIFF
--- a/src/utils/urlNormalizer.js
+++ b/src/utils/urlNormalizer.js
@@ -10,5 +10,7 @@ export function getFormattedPath(url) {
 
 export function urlNormalize(url) {
   if (!url) return "";
+  //Absolute http(s) URLs are returned unchanged.
+  if (/^https?:\/\//.test(url)) return url;
   return `${IPFS_GATEWAY}${getFormattedPath(url)}`;
 }


### PR DESCRIPTION
Resolves #288.